### PR TITLE
[Project 1] alarm_clock

### DIFF
--- a/pintos/include/devices/timer.h
+++ b/pintos/include/devices/timer.h
@@ -3,21 +3,24 @@
 
 #include <round.h>
 #include <stdint.h>
+#include "threads/thread.h"
 
 /* Number of timer interrupts per second. */
 #define TIMER_FREQ 100
 
-void timer_init (void);
-void timer_calibrate (void);
+void timer_init(void);
+void timer_calibrate(void);
 
-int64_t timer_ticks (void);
-int64_t timer_elapsed (int64_t);
+int64_t timer_ticks(void);
+int64_t timer_elapsed(int64_t);
 
-void timer_sleep (int64_t ticks);
-void timer_msleep (int64_t milliseconds);
-void timer_usleep (int64_t microseconds);
-void timer_nsleep (int64_t nanoseconds);
+void timer_sleep(int64_t ticks);
+void timer_msleep(int64_t milliseconds);
+void timer_usleep(int64_t microseconds);
+void timer_nsleep(int64_t nanoseconds);
 
-void timer_print_stats (void);
+void timer_print_stats(void);
+
+static void wake_up_threads(void); // 함수 선언
 
 #endif /* devices/timer.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -9,24 +9,29 @@
 #include "vm/vm.h"
 #endif
 
+/* 스케줄러가 관리하는 Ready Queue */
+extern struct list ready_list;
+/* timer_sleep()에 빠진 스레드를 보관하는 슬립 큐 */
+extern struct list sleep_list;
 
 /* States in a thread's life cycle. */
-enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+enum thread_status
+{
+	THREAD_RUNNING, /* Running thread. */
+	THREAD_READY,		/* Not running but ready to run. */
+	THREAD_BLOCKED, /* Waiting for an event to trigger. */
+	THREAD_DYING		/* About to be destroyed. */
 };
 
 /* Thread identifier type.
-   You can redefine this to whatever type you like. */
+	 You can redefine this to whatever type you like. */
 typedef int tid_t;
-#define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
+#define TID_ERROR ((tid_t) - 1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0			 /* Lowest priority. */
+#define PRI_DEFAULT 31 /* Default priority. */
+#define PRI_MAX 63		 /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -85,19 +90,21 @@ typedef int tid_t;
  * only because they are mutually exclusive: only a thread in the
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
-struct thread {
+struct thread
+{
 	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
+	tid_t tid;								 // 4B		/* Thread identifier. */
+	enum thread_status status; // 4B  	/* Thread state. */
+	char name[16];						 // 16B  /* Name (for debugging purposes). */
+	int priority;							 // 4B   /* Priority. */
+	int wake_up_tick;					 // 4B
 
 	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element. */
+	struct list_elem elem; // 16B -> prev(8B) + next(8B)  /* List element. */
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+	uint64_t *pml4; /* Page map level 4 */
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
@@ -105,42 +112,49 @@ struct thread {
 #endif
 
 	/* Owned by thread.c. */
-	struct intr_frame tf;               /* Information for switching */
-	unsigned magic;                     /* Detects stack overflow. */
+	struct intr_frame tf; /* Information for switching */
+	unsigned magic;				/* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.
-   If true, use multi-level feedback queue scheduler.
-   Controlled by kernel command-line option "-o mlfqs". */
+	 If true, use multi-level feedback queue scheduler.
+	 Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void *aux);
+tid_t thread_create(const char *name, int priority, thread_func *, void *);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread *);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread *thread_current(void);
+tid_t thread_tid(void);
+const char *thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame *tf);
+
+/* priority 기준 내림차순 정렬 함수 (높은 priority 우선) */
+bool compare_priority_desc(const struct list_elem *a,
+													 const struct list_elem *b,
+													 void *aus UNUSED);
+
+void do_thread_ready(struct thread *t);
 
 #endif /* threads/thread.h */


### PR DESCRIPTION
### 개요
alarm-clock 테스트를 통과하기 위해 타이머 서브시스템에 다음 기능을 추가했습니다.

### 변경 사항
- `timer_sleep()` 구현
   - 지정된 틱 수만큼 스레드를 block 상태로 대기시킴
   - sleep_list에 들어간 스레드를 관리
- `wake_up_threads()`
   - 매 타이머 인터럽트마다 sleep_list를 스캔
   - 깨어날 시점을 지난 스레드를 READY 큐로 이동시킴
- 즉시 선점 지원
   - `timer_interrupt()` 후 `intr_yield_on_return()`  호출로 높은 우선순위 스레드 즉시 실행 보장
- 경계값 처리
   - `timer_sleep(0)` 또는 음수 입력 시 즉시 반환하도록 예외 처리

### 검증
- 기존 alarm-clock 테스트(`alarm-single`, `alarm-multiple`) 모두 성공
- 타이머 정확도 및 스케줄링 선점 동작 수동 확인

---
### 통과된 테스트
<img width="251" height="199" alt="alarm_test" src="https://github.com/user-attachments/assets/27e613f6-c423-4c47-a037-ebabc42547a6" />