### PR TITLE
[Project 1] alarm_clock, priority_scheduling

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -38,7 +38,7 @@ static int64_t next_wake_tick = INT64_MAX;
 static bool
 compare_wake_up_tick_asc(const struct list_elem *a,
 												 const struct list_elem *b,
-												 void *aus UNUSED);
+												 void *aux UNUSED);
 
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
 	 interrupt PIT_FREQ times per second, and registers the
@@ -221,7 +221,7 @@ real_time_sleep(int64_t num, int32_t denom)
 static bool
 compare_wake_up_tick_asc(const struct list_elem *a,
 												 const struct list_elem *b,
-												 void *aus UNUSED)
+												 void *aux UNUSED)
 {
 	const struct thread *t_a = list_entry(a, struct thread, elem);
 	const struct thread *t_b = list_entry(b, struct thread, elem);

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -152,7 +152,6 @@ timer_interrupt(struct intr_frame *args UNUSED)
 	if (next_wake_tick <= ticks)
 		wake_up_threads();
 	thread_tick();
-	intr_yield_on_return();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/pintos/include/devices/timer.h
+++ b/pintos/include/devices/timer.h
@@ -3,21 +3,24 @@
 
 #include <round.h>
 #include <stdint.h>
+#include "threads/thread.h"
 
 /* Number of timer interrupts per second. */
 #define TIMER_FREQ 100
 
-void timer_init (void);
-void timer_calibrate (void);
+void timer_init(void);
+void timer_calibrate(void);
 
-int64_t timer_ticks (void);
-int64_t timer_elapsed (int64_t);
+int64_t timer_ticks(void);
+int64_t timer_elapsed(int64_t);
 
-void timer_sleep (int64_t ticks);
-void timer_msleep (int64_t milliseconds);
-void timer_usleep (int64_t microseconds);
-void timer_nsleep (int64_t nanoseconds);
+void timer_sleep(int64_t ticks);
+void timer_msleep(int64_t milliseconds);
+void timer_usleep(int64_t microseconds);
+void timer_nsleep(int64_t nanoseconds);
 
-void timer_print_stats (void);
+void timer_print_stats(void);
+
+static void wake_up_threads(void); // 함수 선언
 
 #endif /* devices/timer.h */

--- a/pintos/include/threads/synch.h
+++ b/pintos/include/threads/synch.h
@@ -5,44 +5,47 @@
 #include <stdbool.h>
 
 /* A counting semaphore. */
-struct semaphore {
-	unsigned value;             /* Current value. */
-	struct list waiters;        /* List of waiting threads. */
+struct semaphore
+{
+	unsigned value;			 /* Current value. */
+	struct list waiters; /* List of waiting threads. */
 };
 
-void sema_init (struct semaphore *, unsigned value);
-void sema_down (struct semaphore *);
-bool sema_try_down (struct semaphore *);
-void sema_up (struct semaphore *);
-void sema_self_test (void);
+void sema_init(struct semaphore *, unsigned value);
+void sema_down(struct semaphore *);
+bool sema_try_down(struct semaphore *);
+void sema_up(struct semaphore *);
+void sema_self_test(void);
 
 /* Lock. */
-struct lock {
-	struct thread *holder;      /* Thread holding lock (for debugging). */
+struct lock
+{
+	struct thread *holder;			/* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
 };
 
-void lock_init (struct lock *);
-void lock_acquire (struct lock *);
-bool lock_try_acquire (struct lock *);
-void lock_release (struct lock *);
-bool lock_held_by_current_thread (const struct lock *);
+void lock_init(struct lock *);
+void lock_acquire(struct lock *);
+bool lock_try_acquire(struct lock *);
+void lock_release(struct lock *);
+bool lock_held_by_current_thread(const struct lock *);
 
 /* Condition variable. */
-struct condition {
-	struct list waiters;        /* List of waiting threads. */
+struct condition
+{
+	struct list waiters; /* List of waiting threads. */
 };
 
-void cond_init (struct condition *);
-void cond_wait (struct condition *, struct lock *);
-void cond_signal (struct condition *, struct lock *);
-void cond_broadcast (struct condition *, struct lock *);
+void cond_init(struct condition *);
+void cond_wait(struct condition *, struct lock *);
+void cond_signal(struct condition *, struct lock *);
+void cond_broadcast(struct condition *, struct lock *);
 
 /* Optimization barrier.
  *
  * The compiler will not reorder operations across an
  * optimization barrier.  See "Optimization Barriers" in the
  * reference guide for more information.*/
-#define barrier() asm volatile ("" : : : "memory")
+#define barrier() asm volatile("" : : : "memory")
 
 #endif /* threads/synch.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -9,24 +9,29 @@
 #include "vm/vm.h"
 #endif
 
+/* 스케줄러가 관리하는 Ready Queue */
+extern struct list ready_list;
+/* timer_sleep()에 빠진 스레드를 보관하는 슬립 큐 */
+extern struct list sleep_list;
 
 /* States in a thread's life cycle. */
-enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+enum thread_status
+{
+	THREAD_RUNNING, /* Running thread. */
+	THREAD_READY,		/* Not running but ready to run. */
+	THREAD_BLOCKED, /* Waiting for an event to trigger. */
+	THREAD_DYING		/* About to be destroyed. */
 };
 
 /* Thread identifier type.
-   You can redefine this to whatever type you like. */
+	 You can redefine this to whatever type you like. */
 typedef int tid_t;
-#define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
+#define TID_ERROR ((tid_t) - 1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0			 /* Lowest priority. */
+#define PRI_DEFAULT 31 /* Default priority. */
+#define PRI_MAX 63		 /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -85,19 +90,21 @@ typedef int tid_t;
  * only because they are mutually exclusive: only a thread in the
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
-struct thread {
+struct thread
+{
 	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
+	tid_t tid;								 // 4B		/* Thread identifier. */
+	enum thread_status status; // 4B  	/* Thread state. */
+	char name[16];						 // 16B  /* Name (for debugging purposes). */
+	int priority;							 // 4B   /* Priority. */
+	int wake_up_tick;					 // 4B
 
 	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element. */
+	struct list_elem elem; // 16B -> prev(8B) + next(8B)  /* List element. */
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+	uint64_t *pml4; /* Page map level 4 */
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
@@ -105,42 +112,49 @@ struct thread {
 #endif
 
 	/* Owned by thread.c. */
-	struct intr_frame tf;               /* Information for switching */
-	unsigned magic;                     /* Detects stack overflow. */
+	struct intr_frame tf; /* Information for switching */
+	unsigned magic;				/* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.
-   If true, use multi-level feedback queue scheduler.
-   Controlled by kernel command-line option "-o mlfqs". */
+	 If true, use multi-level feedback queue scheduler.
+	 Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void *aux);
+tid_t thread_create(const char *name, int priority, thread_func *, void *);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread *);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread *thread_current(void);
+tid_t thread_tid(void);
+const char *thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame *tf);
+
+/* priority 기준 내림차순 정렬 함수 (높은 priority 우선) */
+bool compare_priority_desc(const struct list_elem *a,
+													 const struct list_elem *b,
+													 void *aus UNUSED);
+
+void do_thread_ready(struct thread *t);
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -153,7 +153,7 @@ void do_iret(struct intr_frame *tf);
 /* priority 기준 내림차순 정렬 함수 (높은 priority 우선) */
 bool compare_priority_desc(const struct list_elem *a,
 													 const struct list_elem *b,
-													 void *aus UNUSED);
+													 void *aux UNUSED);
 
 void do_thread_ready(struct thread *t);
 

--- a/pintos/tests/internal/list.c
+++ b/pintos/tests/internal/list.c
@@ -12,163 +12,148 @@
 #include <list.h>
 #include <random.h>
 #include <stdio.h>
-#include "threads/test.h"
 
 /* Maximum number of elements in a linked list that we will
    test. */
 #define MAX_SIZE 64
 
 /* A linked list element. */
-struct value 
-  {
-    struct list_elem elem;      /* List element. */
-    int value;                  /* Item value. */
-  };
+struct value
+{
+  struct list_elem elem; /* List element. */
+  int value;             /* Item value. */
+};
 
-static void shuffle (struct value[], size_t);
-static bool value_less (const struct list_elem *, const struct list_elem *,
-                        void *);
-static void verify_list_fwd (struct list *, int size);
-static void verify_list_bkwd (struct list *, int size);
+static void shuffle(struct value[], size_t);
+static bool value_less(const struct list_elem *, const struct list_elem *,
+                       void *);
+static void verify_list_fwd(struct list *, int size);
+static void verify_list_bkwd(struct list *, int size);
 
 /* Test the linked list implementation. */
-void
-test (void) 
+void test(void)
 {
   int size;
 
-  printf ("testing various size lists:");
-  for (size = 0; size < MAX_SIZE; size++) 
+  printf("testing various size lists:");
+  for (size = 0; size < MAX_SIZE; size++)
+  {
+    int repeat;
+
+    printf(" %d", size);
+    for (repeat = 0; repeat < 10; repeat++)
     {
-      int repeat;
+      static struct value values[MAX_SIZE * 4];
+      struct list list;
+      struct list_elem *e;
+      int i, ofs;
 
-      printf (" %d", size);
-      for (repeat = 0; repeat < 10; repeat++) 
+      /* Put values 0...SIZE in random order in VALUES. */
+      for (i = 0; i < size; i++)
+        values[i].value = i;
+      shuffle(values, size);
+
+      /* Assemble list. */
+      list_init(&list);
+      for (i = 0; i < size; i++)
+        list_push_back(&list, &values[i].elem);
+
+      /* Verify correct minimum and maximum elements. */
+      e = list_min(&list, value_less, NULL);
+      ASSERT(size ? list_entry(e, struct value, elem)->value == 0
+                  : e == list_begin(&list));
+      e = list_max(&list, value_less, NULL);
+      ASSERT(size ? list_entry(e, struct value, elem)->value == size - 1
+                  : e == list_begin(&list));
+
+      /* Sort and verify list. */
+      list_sort(&list, value_less, NULL);
+      verify_list_fwd(&list, size);
+
+      /* Reverse and verify list. */
+      list_reverse(&list);
+      verify_list_bkwd(&list, size);
+
+      /* Shuffle, insert using list_insert_ordered(),
+         and verify ordering. */
+      shuffle(values, size);
+      list_init(&list);
+      for (i = 0; i < size; i++)
+        list_insert_ordered(&list, &values[i].elem,
+                            value_less, NULL);
+      verify_list_fwd(&list, size);
+
+      /* Duplicate some items, uniquify, and verify. */
+      ofs = size;
+      for (e = list_begin(&list); e != list_end(&list);
+           e = list_next(e))
+      {
+        struct value *v = list_entry(e, struct value, elem);
+        int copies = random_ulong() % 4;
+        while (copies-- > 0)
         {
-          static struct value values[MAX_SIZE * 4];
-          struct list list;
-          struct list_elem *e;
-          int i, ofs;
-
-          /* Put values 0...SIZE in random order in VALUES. */
-          for (i = 0; i < size; i++)
-            values[i].value = i;
-          shuffle (values, size);
-  
-          /* Assemble list. */
-          list_init (&list);
-          for (i = 0; i < size; i++)
-            list_push_back (&list, &values[i].elem);
-
-          /* Verify correct minimum and maximum elements. */
-          e = list_min (&list, value_less, NULL);
-          ASSERT (size ? list_entry (e, struct value, elem)->value == 0
-                  : e == list_begin (&list));
-          e = list_max (&list, value_less, NULL);
-          ASSERT (size ? list_entry (e, struct value, elem)->value == size - 1
-                  : e == list_begin (&list));
-
-          /* Sort and verify list. */
-          list_sort (&list, value_less, NULL);
-          verify_list_fwd (&list, size);
-
-          /* Reverse and verify list. */
-          list_reverse (&list);
-          verify_list_bkwd (&list, size);
-
-          /* Shuffle, insert using list_insert_ordered(),
-             and verify ordering. */
-          shuffle (values, size);
-          list_init (&list);
-          for (i = 0; i < size; i++)
-            list_insert_ordered (&list, &values[i].elem,
-                                 value_less, NULL);
-          verify_list_fwd (&list, size);
-
-          /* Duplicate some items, uniquify, and verify. */
-          ofs = size;
-          for (e = list_begin (&list); e != list_end (&list);
-               e = list_next (e))
-            {
-              struct value *v = list_entry (e, struct value, elem);
-              int copies = random_ulong () % 4;
-              while (copies-- > 0) 
-                {
-                  values[ofs].value = v->value;
-                  list_insert (e, &values[ofs++].elem);
-                }
-            }
-          ASSERT ((size_t) ofs < sizeof values / sizeof *values);
-          list_unique (&list, NULL, value_less, NULL);
-          verify_list_fwd (&list, size);
+          values[ofs].value = v->value;
+          list_insert(e, &values[ofs++].elem);
         }
+      }
+      ASSERT((size_t)ofs < sizeof values / sizeof *values);
+      list_unique(&list, NULL, value_less, NULL);
+      verify_list_fwd(&list, size);
     }
-  
-  printf (" done\n");
-  printf ("list: PASS\n");
+  }
+
+  printf(" done\n");
+  printf("list: PASS\n");
 }
 
 /* Shuffles the CNT elements in ARRAY into random order. */
 static void
-shuffle (struct value *array, size_t cnt) 
+shuffle(struct value *array, size_t cnt)
 {
   size_t i;
 
   for (i = 0; i < cnt; i++)
-    {
-      size_t j = i + random_ulong () % (cnt - i);
-      struct value t = array[j];
-      array[j] = array[i];
-      array[i] = t;
-    }
-}
-
-/* Returns true if value A is less than value B, false
-   otherwise. */
-static bool
-value_less (const struct list_elem *a_, const struct list_elem *b_,
-            void *aux UNUSED) 
-{
-  const struct value *a = list_entry (a_, struct value, elem);
-  const struct value *b = list_entry (b_, struct value, elem);
-  
-  return a->value < b->value;
+  {
+    size_t j = i + random_ulong() % (cnt - i);
+    struct value t = array[j];
+    array[j] = array[i];
+    array[i] = t;
+  }
 }
 
 /* Verifies that LIST contains the values 0...SIZE when traversed
    in forward order. */
-static void
-verify_list_fwd (struct list *list, int size) 
+static void verify_list_fwd(struct list *list, int size)
 {
   struct list_elem *e;
   int i;
-  
-  for (i = 0, e = list_begin (list);
-       i < size && e != list_end (list);
-       i++, e = list_next (e)) 
-    {
-      struct value *v = list_entry (e, struct value, elem);
-      ASSERT (i == v->value);
-    }
-  ASSERT (i == size);
-  ASSERT (e == list_end (list));
+
+  for (i = 0, e = list_begin(list);
+       i < size && e != list_end(list);
+       i++, e = list_next(e))
+  {
+    struct value *v = list_entry(e, struct value, elem);
+    ASSERT(i == v->value);
+  }
+  ASSERT(i == size);
+  ASSERT(e == list_end(list));
 }
 
 /* Verifies that LIST contains the values 0...SIZE when traversed
    in reverse order. */
 static void
-verify_list_bkwd (struct list *list, int size) 
+verify_list_bkwd(struct list *list, int size)
 {
   struct list_elem *e;
   int i;
 
-  for (i = 0, e = list_rbegin (list);
-       i < size && e != list_rend (list);
-       i++, e = list_prev (e)) 
-    {
-      struct value *v = list_entry (e, struct value, elem);
-      ASSERT (i == v->value);
-    }
-  ASSERT (i == size);
-  ASSERT (e == list_rend (list));
+  for (i = 0, e = list_rbegin(list);
+       i < size && e != list_rend(list);
+       i++, e = list_prev(e))
+  {
+    struct value *v = list_entry(e, struct value, elem);
+    ASSERT(i == v->value);
+  }
+  ASSERT(i == size);
+  ASSERT(e == list_rend(list));
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -32,6 +32,11 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static bool
+compare_sema_priority_desc(const struct list_elem *a,
+													 const struct list_elem *b,
+													 void *aux UNUSED);
+
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
 	 nonnegative integer along with two atomic operators for
 	 manipulating it:
@@ -182,6 +187,17 @@ sema_test_helper(void *sema_)
 	 acquire and release it.  When these restrictions prove
 	 onerous, it's a good sign that a semaphore should be used,
 	 instead of a lock. */
+/* Lock을 초기화한다. 락은 한 번에 최대 하나의 스레드만 소유할 수 있다.
+	 이 락은 재귀적(recursion)이 아니므로, 이미 락을 소유한 스레드가
+	 다시 동일한 락을 획득하려고 하면 오류가 발생한다.
+
+	 이 락은 초기값이 1인 세마포어의 특수한 형태이다.
+	 락과 일반 세마포어의 차이점은 두 가지이다.
+	 첫째, 세마포어는 값이 1보다 클 수 있지만, 락은 항상 하나의 스레드만 소유할 수 있다.
+	 둘째, 세마포어에는 소유자 개념이 없어서 한 스레드가 down 연산을 하고
+	 다른 스레드가 up 연산을 수행해도 되지만,
+	 라은 반드시 같은 스레드가 획득(acquire)하고 해제(release)해야 한다.
+	 이 제약이 부담스럽다면, 락 대신 세마포어를 사용하는 것이 좋다.*/
 void lock_init(struct lock *lock)
 {
 	ASSERT(lock != NULL);
@@ -198,6 +214,12 @@ void lock_init(struct lock *lock)
 	 interrupt handler.  This function may be called with
 	 interrupts disabled, but interrupts will be turned back on if
 	 we need to sleep. */
+/* 락(LOCK)을 획득한다. 필요하다면 사용 가능해질 때까지 대기(sleep)한다.
+	 현재 스레드가 이미 이 락을 소유하고 있어서는 안 된다.
+
+	 이 함수는 대기 상태로 들어갈 수 있으므로, 인터럽트 핸들러 내에서 호출하면 안 된다.
+	 또한 인터럽트가 비활성화된 상태에서도 호출할 수 있지만,
+	 대기할 때는 인터럽트를 다시 활성화한다. */
 void lock_acquire(struct lock *lock)
 {
 	ASSERT(lock != NULL);
@@ -214,6 +236,10 @@ void lock_acquire(struct lock *lock)
 
 	 This function will not sleep, so it may be called within an
 	 interrupt handler. */
+/* LOCK을 획득 시도하고, 성공하면 true를, 실패하면 false를 반환한다.
+	 현재 스레드가 이미 이 락을 소유하고 있어서는 안 된다.
+
+	 이 함수는 대기 상태(sleep)를 발생시키지 않으므로, 인터럽트 핸들러 내에서도 호출할 수 있다.*/
 bool lock_try_acquire(struct lock *lock)
 {
 	bool success;
@@ -233,6 +259,11 @@ bool lock_try_acquire(struct lock *lock)
 	 An interrupt handler cannot acquire a lock, so it does not
 	 make sense to try to release a lock within an interrupt
 	 handler. */
+/* LOCK을 해제한다. 이 락은 반드시 현재 스레드가 소유하고 있어야 한다.
+	 이것이 Lock_release 함수이다.
+
+	 인터럽트 핸들러는 락을 획득할 수 없으므로,
+	 인터럽트 핸들러 내에서 락을 해제하는 것은 의미가 없다. */
 void lock_release(struct lock *lock)
 {
 	ASSERT(lock != NULL);
@@ -245,6 +276,8 @@ void lock_release(struct lock *lock)
 /* Returns true if the current thread holds LOCK, false
 	 otherwise.  (Note that testing whether some other thread holds
 	 a lock would be racy.) */
+/* 현재 스레드가 LOCK을 소유하고 있으면 true를, 그렇지 않으면 false를 반환한다.
+	 (다른 스레드가 락을 소유하고 있는지 검사하는 것은 경쟁(race)이 발생할 수 있다.) */
 bool lock_held_by_current_thread(const struct lock *lock)
 {
 	ASSERT(lock != NULL);
@@ -257,11 +290,15 @@ struct semaphore_elem
 {
 	struct list_elem elem;			/* List element. */
 	struct semaphore semaphore; /* This semaphore. */
+	int priority;								/* 대기 시작 시점의 스레드 우선순위 */
 };
 
 /* Initializes condition variable COND.  A condition variable
 	 allows one piece of code to signal a condition and cooperating
 	 code to receive the signal and act upon it. */
+/* 조건 변수 COND를 초기화한다.
+	 조건 변수는 한쪽 코드가 어떤 조건을 신호(signaling)하면,
+	 협력하는 다른 코드가 그 신호를 받아 처리할 수 있도록 해 준다. */
 void cond_init(struct condition *cond)
 {
 	ASSERT(cond != NULL);
@@ -289,6 +326,22 @@ void cond_init(struct condition *cond)
 	 interrupt handler.  This function may be called with
 	 interrupts disabled, but interrupts will be turned back on if
 	 we need to sleep. */
+/* LOCK을 원자적으로 해제한 뒤, COND가 다른 코드에 의해 신호(signaled)될 때까지 대기한다.
+	 COND에 신호가 발생하면, 반환하기 전에 LOCK을 다시 획득한다.
+	 이 함수를 호출하기 전에 LOCK이 이미 획득되어 있어야 한다.
+
+	 이 함수가 구현하는 모니터는 "Mesa" 스타일이며, "Hoare" 스타일이 아니다.
+	 즉, 신호를 보내는 것과 받는 것은 원자적인 연산이 아니므로,
+	 일반적으로 대기가 끝난 후에는 조건을 다시 검사하고,
+	 필요하다면 다시 대기해야 한다.
+
+	 하나의 조건 변수는 단 하나의 락과 연결되지만,
+	 하나의 락은 여러 개의 조건 변수와 연결될 수 있다.
+	 즉, 락 하나에 조건 변수가 여러 개 매핑될 수 있다.
+
+	 이 함수는 잠들 수 있으므로, 인터럽트 핸들러 내부에서 호출해서는 안 된다.
+	 또한, 인터럽트가 비활성화된 상태에서 호출할 수 있으나,
+	 대기 상태로 들어가면 인터럽는 다시 활성화된다.*/
 void cond_wait(struct condition *cond, struct lock *lock)
 {
 	struct semaphore_elem waiter;
@@ -299,7 +352,8 @@ void cond_wait(struct condition *cond, struct lock *lock)
 	ASSERT(lock_held_by_current_thread(lock));
 
 	sema_init(&waiter.semaphore, 0);
-	list_push_back(&cond->waiters, &waiter.elem);
+	waiter.priority = thread_current()->priority;
+	list_insert_ordered(&cond->waiters, &waiter.elem, compare_sema_priority_desc, NULL);
 	lock_release(lock);
 	sema_down(&waiter.semaphore);
 	lock_acquire(lock);
@@ -312,6 +366,12 @@ void cond_wait(struct condition *cond, struct lock *lock)
 	 An interrupt handler cannot acquire a lock, so it does not
 	 make sense to try to signal a condition variable within an
 	 interrupt handler. */
+/* 만약 LOCK으로 보호된 COND에 대기 중인 스레드가 있다면,
+	 그중 하나에게 신호를 보내 대기에서 깨어나도록 한다.
+	 이 함수를 호출하기 전에 LOCK이 반드시 획득되어 있어야 한다.
+
+	 인터럽트 핸들러는 락을 획득할 수 없으므로,
+	 인터럽트 핸들러 내에서 조건 변수에 신호를 보내는 것은 의미가 없다. */
 void cond_signal(struct condition *cond, struct lock *lock UNUSED)
 {
 	ASSERT(cond != NULL);
@@ -320,9 +380,9 @@ void cond_signal(struct condition *cond, struct lock *lock UNUSED)
 	ASSERT(lock_held_by_current_thread(lock));
 
 	if (!list_empty(&cond->waiters))
-		sema_up(&list_entry(list_pop_front(&cond->waiters),
-												struct semaphore_elem, elem)
-								 ->semaphore);
+	{
+		sema_up(&list_entry(list_pop_front(&cond->waiters), struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
@@ -331,6 +391,11 @@ void cond_signal(struct condition *cond, struct lock *lock UNUSED)
 	 An interrupt handler cannot acquire a lock, so it does not
 	 make sense to try to signal a condition variable within an
 	 interrupt handler. */
+/* LOCK으로 보호된 COND에 대기 중인 모든 스레드를 깨운다.
+	 이 함수를 호출하기 전에 LOCK이 반드시 획득되어 있어야 한다.
+
+	 인터럽트 핸들러는 락을 획득할 수 없으므로,
+	 인터럽트 핸들러 내부에서 조건 변수에 신호를 보내는 것은 의미가 없다. */
 void cond_broadcast(struct condition *cond, struct lock *lock)
 {
 	ASSERT(cond != NULL);
@@ -338,4 +403,15 @@ void cond_broadcast(struct condition *cond, struct lock *lock)
 
 	while (!list_empty(&cond->waiters))
 		cond_signal(cond, lock);
+}
+
+static bool
+compare_sema_priority_desc(const struct list_elem *a,
+													 const struct list_elem *b,
+													 void *aux UNUSED)
+{
+	struct semaphore_elem *sema_a = list_entry(a, struct semaphore_elem, elem);
+	struct semaphore_elem *sema_b = list_entry(b, struct semaphore_elem, elem);
+
+	return sema_a->priority > sema_b->priority;
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -246,7 +246,7 @@ void thread_block()
 /* priority 기준 내림차순 정렬 함수 (높은 priority 우선) */
 bool compare_priority_desc(const struct list_elem *a,
 													 const struct list_elem *b,
-													 void *aus UNUSED)
+													 void *aux UNUSED)
 {
 	const struct thread *t_a = list_entry(a, struct thread, elem);
 	const struct thread *t_b = list_entry(b, struct thread, elem);


### PR DESCRIPTION
### 개요
다음 priority 관련 테스트를 모두 통과하기 위해 스케줄러와 동기화 원시(세마포어·조건 변수)를 우선순위 기반으로 개선했다.

### 변경 사항

1. 선점형 우선순위 스케줄러
   - READY 큐를 우선순위 내림차순으로 정렬하도록 `list_insert_ordered` 적용 (priority-FIFO)
   - `thread_create()`, `thread_set_priority()`, `thread_unblock()` 등 일반 경로에서 우선순위 비교 후 즉시 `thread_yield` 호출 (priority-preempt)
   - `timer_interrupt()` 내부에서`intr_yield_on_return()` 호출로 즉시 선점 보장 (priority-preempt)

2. 세마포어(priority-sema)
   - `sema_down()` 시 waiters 리스트에 우선순위 내림차순 삽입
   - `sema_up()` 시 가장 높은 우선순위 스레드를 먼저 깨우도록 `list_pop_front` 사용

3. 조건 변수(priority-condvar)
   - `semaphore_elem`에 대기 스레드 우선순위 스냅샷 필드 추가
   - `cond_wait()`에서 `list_insert_ordered`로 우선순위 기반 대기자 관리
   - `cond_signal()`에서 `list_pop_front`로 가장 높은 우선순위 대기자 깨우기

---
### 통과된 테스트
<img width="242" height="177" alt="image" src="https://github.com/user-attachments/assets/2245a01d-936d-4d2b-8b7b-46c86414de33" />