### PR TITLE
feat: 프로세스 관리 및 시스템 콜 구현 (fork, exec, wait, exit, 파일 관련 syscall)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,22 @@
         "*.inc": "c",
         "lib.h": "c",
         "inode.h": "c",
-        "interrupt.h": "c"
+        "interrupt.h": "c",
+        "file.h": "c",
+        "off_t.h": "c",
+        "loader.h": "c",
+        "filesys.h": "c",
+        "syscall.h": "c",
+        "synch.h": "c",
+        "mmu.h": "c",
+        "types.h": "c",
+        "gdt.h": "c",
+        "process.h": "c",
+        "flags.h": "c",
+        "vaddr.h": "c",
+        "util.h": "c",
+        "stddef.h": "c",
+        "main.h": "c",
+        "init.h": "c"
     },
 }

--- a/pintos/include/devices/disk.h
+++ b/pintos/include/devices/disk.h
@@ -23,5 +23,5 @@ disk_sector_t disk_size(struct disk *);
 void disk_read(struct disk *, disk_sector_t, void *);
 void disk_write(struct disk *, disk_sector_t, const void *);
 
-void register_disk_inspect_intr();
+void register_disk_inspect_intr(void);
 #endif /* devices/disk.h */

--- a/pintos/include/lib/user/syscall.h
+++ b/pintos/include/lib/user/syscall.h
@@ -7,7 +7,7 @@
 
 /* Process identifier. */
 typedef int pid_t;
-#define PID_ERROR ((pid_t) -1)
+#define PID_ERROR ((pid_t) - 1)
 
 /* Map region identifier. */
 typedef int off_t;
@@ -25,7 +25,7 @@ void halt(void) NO_RETURN;
 void exit(int status) NO_RETURN;
 pid_t fork(const char *thread_name);
 int exec(const char *file);
-int wait(pid_t);
+int wait(pid_t pid);
 bool create(const char *file, unsigned initial_size);
 bool remove(const char *file);
 int open(const char *file);

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -9,5 +9,9 @@ int process_exec(void *f_name);
 int process_wait(tid_t);
 void process_exit(void);
 void process_activate(struct thread *next);
+struct thread *process_get_child(tid_t tid);
+struct uni_file *process_get_file(int fd);
+int process_add_file(struct file *file);
+void process_init_fdt(struct thread *t);
 
 #endif /* userprog/process.h */

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -1,10 +1,8 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
-#define is_fd_readable(fd) (fd >= 2 && fd < 128)
-#define is_fd_writable(fd) (fd >= 1 && fd < 128)
 
+extern struct lock filesys_lock;
 void syscall_init(void);
-struct file *process_get_file(int fd);
-int process_add_file(struct file *file);
+void check_address(void *addr);
 
 #endif /* userprog/syscall.h */

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -1,5 +1,7 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
+#define is_fd_readable(fd) (fd >= 2 && fd < 128)
+#define is_fd_writable(fd) (fd >= 1 && fd < 128)
 
 void syscall_init(void);
 struct file *process_get_file(int fd);

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include "include/lib/user/syscall.h"
 #include "intrinsic.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
@@ -154,5 +155,5 @@ static void page_fault(struct intr_frame *f)
     printf("Page fault at %p: %s error %s page in %s context.\n", fault_addr,
            not_present ? "not present" : "rights violation",
            write ? "writing" : "reading", user ? "user" : "kernel");
-    kill(f);
+    exit(-1);
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -135,6 +135,18 @@ void syscall_handler(struct intr_frame *f UNUSED)
         }
         case SYS_READ:
         {
+            struct thread *current_thread = thread_current();
+
+            if ((f->R.rdi < 2 || f->R.rdi > 127) ||
+                check_bad_addr(f->R.rsi, current_thread) == NULL)
+            {
+                current_thread->tf.R.rax = -1;
+                thread_exit();
+            }
+
+            struct file *current_file = process_get_file(f->R.rdi);
+            f->R.rax = file_read(current_file, f->R.rsi, f->R.rdx);
+            break;
         }
         case SYS_WRITE:
         {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -3,24 +3,24 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 
+#include "include/devices/input.h"
 #include "include/filesys/file.h"
 #include "include/filesys/filesys.h"
+#include "include/lib/string.h"
+#include "include/lib/user/syscall.h"
+#include "include/threads/init.h"
+#include "include/userprog/process.h"
 #include "intrinsic.h"
 #include "lib/kernel/console.h"
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/loader.h"
+#include "threads/malloc.h"
 #include "threads/thread.h"
 #include "userprog/gdt.h"
 
 void syscall_entry(void);
 void syscall_handler(struct intr_frame *);
-static bool check_bad_addr();
-static int write_handler(int fd, const void *buffer, unsigned size);
-static int close_handler(int fd);
-struct file *process_get_file(int fd);
-
-static int write_handler(int fd, const void *buffer, unsigned size);
 
 /* System call.
  *
@@ -35,7 +35,31 @@ static int write_handler(int fd, const void *buffer, unsigned size);
 #define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
 #define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
 
-// 시스템 초기화 시 시스템 콜 벡터 설정 등의 초기화 작업 수행
+struct lock filesys_lock;
+
+/* check address for validation
+ * - 커널 영역 접근 차단
+ * - 미매핑 페이지 차단 */
+void check_address(void *vaddr)
+{
+    struct thread *curr = thread_current();
+    if (vaddr == NULL || !is_user_vaddr(vaddr) ||
+        pml4_get_page(curr->pml4, vaddr) == NULL)
+    {
+        exit(-1);
+    }
+}
+
+/* protect from bad file descriptor number */
+void check_fd(int fd)
+{
+    if (fd < 0 || fd > FDTABLE_SIZE)
+    {
+        exit(-1);
+    }
+}
+
+/* 시스템 초기화 시 시스템 콜 벡터 설정 등의 초기화 작업 수행 */
 void syscall_init(void)
 {
     write_msr(MSR_STAR, ((uint64_t) SEL_UCSEG - 0x10) << 48 |
@@ -47,224 +71,376 @@ void syscall_init(void)
      * mode stack. Therefore, we masked the FLAG_FL. */
     write_msr(MSR_SYSCALL_MASK,
               FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+
+    /* initialize filesys lock */
+    lock_init(&filesys_lock);
+}
+
+/* system power off */
+void halt(void)
+{
+    power_off();
+}
+
+/* exit with given status number */
+void exit(int status)
+{
+    struct thread *t = thread_current();
+    t->exit_status = status;
+    printf("%s: exit(%d)\n", t->name,
+           t->exit_status); /* Process Termination Message */
+
+    if (lock_held_by_current_thread(&filesys_lock))
+    {
+        lock_release(&filesys_lock);
+    }
+
+    thread_exit();
+}
+
+// pid_t fork(const char *thread_name)
+// {
+//     struct intr_frame *if_ =
+//         pg_round_up(&thread_name) - sizeof(struct intr_frame);
+//     return process_fork(thread_name, if_);
+// }
+
+/* execute program with given file name */
+int exec(const char *file)
+{
+    check_address(file);
+
+    int result = process_exec(file);
+    if (result == -1)
+    {
+        exit(-1);
+    }
+
+    return result;
+}
+
+/* wait process until it's finish (exit) */
+int wait(pid_t pid)
+{
+    return process_wait(pid);
+}
+
+bool create(const char *file, unsigned initial_size)
+{
+    bool file_create_result = false;
+
+    check_address(file);
+
+    lock_acquire(&filesys_lock);
+    file_create_result = filesys_create(file, initial_size);
+    lock_release(&filesys_lock);
+    return file_create_result;
+}
+
+bool remove(const char *file)
+{
+    check_address(file);
+
+    bool file_remove_result = false;
+
+    lock_acquire(&filesys_lock);
+    file_remove_result = filesys_remove(file);
+    lock_release(&filesys_lock);
+
+    return file_remove_result;
+}
+
+int open(const char *file)
+{
+    check_address(file);
+
+    lock_acquire(&filesys_lock);
+    struct file *open_file = filesys_open(file);
+    lock_release(&filesys_lock);
+
+    if (open_file != NULL)
+    {
+        return process_add_file(open_file);
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+int filesize(int fd)
+{
+    check_fd(fd);
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return -1;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return -1;
+    }
+
+    return file_length(file);
+}
+
+int read(int fd, void *buffer, unsigned length)
+{
+    check_address(buffer);
+    check_fd(fd);
+
+    int bytes_read;
+
+    if (fd == FD_STDIN)
+    {
+        /* >> (1) STDIN - 키보드에서 length 바이트만큼 읽기 */
+        unsigned i;
+        for (i = 0; i < length; i++)
+        {
+            /* 한 글자씩 채움 */
+            ((char *) buffer)[i] = input_getc();
+        }
+
+        return length;
+    }
+    else if (fd == FD_STDOUT)
+    {
+        /* >> (2) STDOUT - Not allowed to read on Write-Only file */
+        return -1;
+    }
+    else
+    {
+        /* >> (3): read from file */
+        struct uni_file *uni_file = process_get_file(fd);
+        if (uni_file == NULL)
+        {
+            return -1;
+        }
+
+        struct file *file = uni_file->ptr;
+        if (file == NULL)
+        {
+            return -1;
+        }
+
+        lock_acquire(&filesys_lock);
+        bytes_read = file_read(file, buffer, length);
+        lock_release(&filesys_lock);
+
+        return bytes_read;
+    }
+}
+
+int write(int fd, const void *buffer, unsigned size)
+{
+    check_address(buffer);
+    check_fd(fd);
+
+    struct thread *curr = thread_current();
+
+    if (fd == FD_STDIN)
+    {
+        /* >> (1): writing on Read-Only file is not allowed */
+        return -1;
+    }
+    else if (fd == FD_STDOUT)
+    {
+        /* >> (2): write on STDOUT */
+        putbuf((char *) buffer, size);
+        return size;
+    }
+    else
+    {
+        /* >> (3): write on file */
+        struct uni_file *uni_file = process_get_file(fd);
+        if (uni_file == NULL)
+        {
+            return -1;
+        }
+
+        struct file *file = uni_file->ptr;
+        if (file == NULL)
+        {
+            return -1;
+        }
+
+        lock_acquire(&filesys_lock);
+        int bytes_written = file_write(file, buffer, size);
+        lock_release(&filesys_lock);
+        return bytes_written;
+    }
+}
+
+/* fd로 열린 파일에서 읽거나 쓸 다음 바이트를 파일 시작부터 position(바이트
+ * 단위) 위치로 설정합니다. (따라서 position이 0이면 파일의 시작을 의미합니다.)
+ * 파일의 현재 끝을 넘어서는 seek는 오류가 아닙니다. 이후 read는 0바이트를
+ * 반환하여 파일 끝을 나타냅니다. 이후 write는 파일을 확장하며,
+ * 쓰이지 않은 간격을 0으로 채웁니다.
+ * (그러나 Pintos에서는 프로젝트 4가 완료될 때까지 파일 길이가 고정되어
+ * 있으므로, 파일 끝을 넘는 쓰기는 오류를 반환합니다.) 이러한 동작 방식은 파일
+ * 시스템에 구현되어 있으므로 system call 구현에서 별도의 작업이 필요하지
+ * 않습니다. */
+void seek(int fd, unsigned position)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return;
+    }
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return;
+    }
+
+    file_seek(file, position);
+}
+
+unsigned tell(int fd)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return 0;
+    }
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return -1;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return;
+    }
+
+    unsigned position = file_tell(file);
+    return position;
+}
+
+void close(int fd)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return;
+    }
+
+    struct thread *curr = thread_current();
+    struct uni_file *uni_file = curr->fd_table[fd];
+    if (uni_file == NULL)
+    {
+        return;
+    }
+
+    if (uni_file->type == FD_FILE && uni_file->ptr != NULL)
+    {
+        lock_acquire(&filesys_lock);
+        file_close((struct file *) uni_file->ptr);
+        lock_release(&filesys_lock);
+    }
+
+    free(uni_file);
+    curr->fd_table[fd] = NULL;
 }
 
 /* The main system call interface */
-// 어셈블리 코드(syscall-entry.S)로부터 제어를 넘겨받음
+/*
+ * 어셈블리 코드(syscall-entry.S)로부터 제어를 넘겨받음
+ * 인터럽트 프레임(struct intr_frame *f)을 통해 사용자 프로그램의
+ * 레지스터 상태와 시스템 콜 번호 및 인자들을 읽어옴
+ */
 void syscall_handler(struct intr_frame *f UNUSED)
 {
-    // 유저 스택에서 시스템콜 번호 꺼내기
+    /* 유저 스택에서 시스템콜 번호 꺼내기 */
     int syscall_number = f->R.rax;
 
     switch (syscall_number)
     {
         case SYS_HALT:
         {
-            power_off();
+            halt();
             break;
         }
         case SYS_EXIT:
         {
-            struct thread *curr = thread_current();
-            curr->tf.R.rax = f->R.rdi;
-            thread_exit();
+            exit(f->R.rdi);
+            break;
         }
         case SYS_FORK:
         {
+            f->R.rax = process_fork(f->R.rdi, f);
+            break;
         }
         case SYS_EXEC:
         {
+            f->R.rax = exec(f->R.rdi);
+            break;
         }
         case SYS_WAIT:
         {
+            f->R.rax = wait(f->R.rdi);
+            break;
         }
         case SYS_CREATE:
         {
-            const char *open_filename = (const char *) f->R.rdi;
-            int32_t filesize = f->R.rsi;
-            struct thread *curr = thread_current();
-
-            if (open_filename == NULL ||
-                check_bad_addr(open_filename, curr) == NULL)
-            {
-                curr->tf.R.rax = -1;
-                thread_exit();
-            }
-            else
-            {
-                f->R.rax = filesys_create(open_filename, filesize);
-                break;
-            }
+            f->R.rax = create(f->R.rdi, f->R.rsi);
+            break;
         }
         case SYS_REMOVE:
         {
+            f->R.rax = remove(f->R.rdi);
+            break;
         }
         case SYS_OPEN:
         {
-            struct thread *curr = thread_current();
-            if (is_user_vaddr(f->R.rdi))
-            {
-                const char *open_filename = (const char *) f->R.rdi;
-                if (open_filename == NULL ||
-                    check_bad_addr(open_filename, curr) == NULL)
-                {
-                    curr->tf.R.rax = -1;
-                    thread_exit();
-                }
-                else
-                {
-                    struct file *open_file = filesys_open(open_filename);
-
-                    if (open_file != NULL)
-                    {
-                        f->R.rax = process_add_file(open_file);
-                    }
-                    else
-                    {
-                        f->R.rax = -1;
-                    }
-                    break;
-                }
-            }
+            f->R.rax = open(f->R.rdi);
+            break;
         }
         case SYS_FILESIZE:
         {
-            struct file *current_file = process_get_file(f->R.rdi);
-            f->R.rax = file_length(current_file);
+            f->R.rax = filesize(f->R.rdi);
             break;
         }
         case SYS_READ:
         {
-            struct thread *current_thread = thread_current();
-
-            if (!is_fd_readable(f->R.rdi) ||
-                check_bad_addr(f->R.rsi, current_thread) == NULL)
-            {
-                current_thread->tf.R.rax = -1;
-                thread_exit();
-            }
-
-            struct file *current_file = process_get_file(f->R.rdi);
-            f->R.rax = file_read(current_file, f->R.rsi, f->R.rdx);
+            f->R.rax = read(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
         }
         case SYS_WRITE:
         {
-            // 인터럽트 프레임(struct intr_frame *f)을 통해 사용자 프로그램의
-            // 레지스터 상태와 시스템 콜 번호 및 인자들을 읽어옴 f->R.rax :
-            // 시스템 콜 반환값 (리턴값 저장) f->R.rdi : 첫 번째 인자 (fd)
-            // f->R.rsi : 두 번째 인자 (buffer)
-            // f->R.rdx : 세 번째 인자 (size)
-            f->R.rax = write_handler(f->R.rdi, f->R.rsi, f->R.rdx);
+            f->R.rax = write(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
         }
         case SYS_SEEK:
         {
+            seek(f->R.rdi, f->R.rsi);
+            break;
         }
         case SYS_TELL:
         {
+            f->R.rax = tell(f->R.rdi);
+            break;
         }
         case SYS_CLOSE:
         {
-            // fd_list에서 fd를 가진 file_fd 찾아서
-            // 리스트에서 제거하고 file_fd 메모리 해제
-            close_handler(f->R.rdi);
+            close(f->R.rdi);
             break;
         }
     }
-}
-
-static bool check_bad_addr(const char *vaddr, struct thread *t)
-{
-    return pml4_get_page(t->pml4, vaddr);
-}
-
-/* 파일 또는 STDOUT으로 쓰기 */
-static int write_handler(int fd, const void *buffer, unsigned size)
-{
-    struct thread *current_thread = thread_current();
-
-    if (!is_fd_writable(fd) || check_bad_addr(buffer, current_thread) == NULL)
-    {
-        current_thread->tf.R.rax = -1;
-        thread_exit();
-    }
-
-    if (!(is_user_vaddr(buffer) && is_user_vaddr(buffer + size)))
-    {
-        return -1;
-    }
-
-    switch (fd)
-    {
-        case 1: /* fd가 1이면 표준 출력 (파일이 아니라 콘솔로 출력) */
-        {
-            putbuf(buffer, size);
-        }
-        default: /* open()으로 연 파일이 할당된 경우 */
-        {
-            struct file *file = process_get_file(fd);
-            if (file == NULL) return -1;
-            return file_write(file, buffer, size);
-        }
-    }
-}
-
-static int close_handler(int fd)
-{
-    struct thread *current_thread = thread_current();
-
-    if (fd < 2 || fd > 127)
-    {
-        return -1;
-    }
-
-    if (current_thread->file_descriptor_table[fd] == NULL)
-    {
-        return -1;
-    }
-    else
-    {
-        current_thread->file_descriptor_table[fd] = NULL;
-        free(current_thread->file_descriptor_table[fd]);
-        return 0;
-    }
-}
-
-// 헌재 실행 중인 프로세스의 열린 파일 리스트에서 특정 파일 디스크립터(fd)에
-// 해당하는 파일 포인터를 찾아 반환
-struct file *process_get_file(int fd)
-{
-    struct thread *current_thread = thread_current();
-
-    if (current_thread->file_descriptor_table[fd]->fd_type == FD_TYPE_FILE &&
-        current_thread->file_descriptor_table[fd]->fd_ptr != NULL)
-    {
-        return current_thread->file_descriptor_table[fd]->fd_ptr;
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-// 현재 실행 중인 프로세스의 열린 파일 리스트에 파일 추가
-int process_add_file(struct file *file)
-{
-    if (file == NULL)
-    {
-        return -1;
-    }
-
-    struct thread *current_thread = thread_current();
-
-    current_thread->file_descriptor_table[current_thread->next_fd] =
-        malloc(sizeof(struct uni_file));
-
-    current_thread->file_descriptor_table[current_thread->next_fd]->fd_type =
-        FD_TYPE_FILE;
-    current_thread->file_descriptor_table[current_thread->next_fd]->fd_ptr =
-        file;
-
-    return current_thread->next_fd++;
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 
+#include "include/filesys/file.h"
 #include "include/filesys/filesys.h"
 #include "intrinsic.h"
 #include "lib/kernel/console.h"
@@ -18,13 +19,6 @@ static bool check_bad_addr();
 static int write_handler(int fd, const void *buffer, unsigned size);
 static int close_handler(int fd);
 struct file *process_get_file(int fd);
-
-struct file_fd
-{
-    int fd;
-    struct file *file;
-    struct list_elem elem;
-};
 
 static int write_handler(int fd, const void *buffer, unsigned size);
 
@@ -75,6 +69,15 @@ void syscall_handler(struct intr_frame *f UNUSED)
             curr->tf.R.rax = f->R.rdi;
             thread_exit();
         }
+        case SYS_FORK:
+        {
+        }
+        case SYS_EXEC:
+        {
+        }
+        case SYS_WAIT:
+        {
+        }
         case SYS_CREATE:
         {
             const char *open_filename = (const char *) f->R.rdi;
@@ -92,6 +95,9 @@ void syscall_handler(struct intr_frame *f UNUSED)
                 f->R.rax = filesys_create(open_filename, filesize);
                 break;
             }
+        }
+        case SYS_REMOVE:
+        {
         }
         case SYS_OPEN:
         {
@@ -121,6 +127,15 @@ void syscall_handler(struct intr_frame *f UNUSED)
                 }
             }
         }
+        case SYS_FILESIZE:
+        {
+            struct file *current_file = process_get_file(f->R.rdi);
+            f->R.rax = file_length(current_file);
+            break;
+        }
+        case SYS_READ:
+        {
+        }
         case SYS_WRITE:
         {
             // 인터럽트 프레임(struct intr_frame *f)을 통해 사용자 프로그램의
@@ -130,6 +145,12 @@ void syscall_handler(struct intr_frame *f UNUSED)
             // f->R.rdx : 세 번째 인자 (size)
             f->R.rax = write_handler(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
+        }
+        case SYS_SEEK:
+        {
+        }
+        case SYS_TELL:
+        {
         }
         case SYS_CLOSE:
         {


### PR DESCRIPTION
## 📑 개요

Pintos 운영체제에 핵심적인 프로세스 관리 기능과 파일 시스템 관련 시스템 콜을 구현합니다. 이 PR을 통해 사용자는 프로세스를 생성(`fork`), 실행(`exec`), 대기(`wait`), 종료(`exit`)할 수 있게 되며, 파일 시스템을 이용한 기본적인 I/O 작업이 가능해집니다.

주요 구현 내용은 다음과 같습니다.
- 프로세스 계층 구조 관리를 위한 자료구조(`struct thread`) 확장
- `fork`, `wait`, `exit` 시스템 콜의 동기화를 위한 세마포어 기반 로직 구현
- 파일 디스크립터(FD) 관리 시스템 개선 및 관련 헬퍼 함수 추가
- 모든 파일 시스템 접근에 대한 동기화를 위한 전역 락(`filesys_lock`) 도입
- 사용자 공간 주소의 유효성을 검증하는 `check_address` 함수 구현
- 전체 시스템 콜 핸들러 리팩토링 및 기능 구현

## ✨ 주요 변경 사항

### 1. 프로세스 관리 및 동기화 (`fork`, `wait`, `exit`)

- **`struct thread` 확장**:
    - `child_list`, `child_elem`: 부모-자식 관계를 관리하기 위한 리스트 구조를 추가했습니다.
    - `parent_if`: `fork` 시 자식 프로세스에게 부모의 인터럽트 프레임을 전달하기 위한 멤버를 추가했습니다.
    - `wait_sema`, `fork_sema`, `exit_sema`: `wait`, `fork`, `exit` 시스템 콜의 동기화를 위해 3개의 세마포어를 추가했습니다.
        - `fork_sema`: `fork` 시 자식 프로세스의 자원 복제가 완료될 때까지 부모가 대기하는 데 사용됩니다.
        - `wait_sema`: 자식 프로세스가 종료될 때까지 부모가 `wait`에서 대기하는 데 사용됩니다.
        - `exit_sema`: `wait`을 호출한 부모가 자식의 종료 상태를 수집한 후, 자식 프로세스가 최종적으로 종료되도록 허용하는 데 사용됩니다.
    - `exit_status`: 자식 프로세스의 종료 코드를 저장하여 부모에게 전달합니다.
    - `wait_called`: 동일한 자식에 대해 `wait`이 중복 호출되는 것을 방지하기 위한 플래그입니다.
    - `running_file`: 현재 실행 중인 실행 파일을 가리키는 포인터로, 프로세스 종료 시 `file_close`를 위함입니다.

- **`process_fork()` 및 `__do_fork()` 구현**:
    - 부모의 자원(페이지 테이블, 파일 디스크립터)을 자식에게 복제합니다.
    - `duplicate_pte`를 통해 부모의 페이지 테이블을 복사하고, `file_duplicate`를 통해 열린 파일들을 복제합니다.
    - `fork_sema`를 사용하여 부모-자식 간의 생성 과정을 동기화합니다. 자식의 `__do_fork`가 성공적으로 끝나야 부모의 `process_fork`가 반환됩니다.

- **`process_wait()` 구현**:
    - `process_get_child()`를 통해 tid로 자식 프로세스를 찾습니다.
    - `wait_sema`를 통해 자식 프로세스가 종료될 때까지 대기(`sema_down`)합니다.
    - 자식의 종료 후 `exit_status`를 반환하고, 자식 리스트에서 해당 자식을 제거합니다.

- **`process_exit()` 구현**:
    - 열려있는 모든 파일 디스크립터를 닫고, 실행 중인 파일(`running_file`)을 `file_close` 합니다.
    - `wait_sema`를 `sema_up`하여 `wait` 중인 부모를 깨웁니다.
    - `exit_sema`를 `sema_down`하여 부모가 `exit_status`를 완전히 처리할 때까지 대기한 후 최종 정리(`process_cleanup`)를 수행합니다.

### 2. 파일 디스크립터(FD) 관리 리팩토링

- **`struct uni_file` 및 `fd_table` 도입**:
    - 기존의 `file_descriptor_table`을 `uni_file` 구조체를 사용하는 `fd_table`로 대체했습니다.
    - `uni_file`은 파일의 타입(`FD_STDIN`, `FD_STDOUT`, `FD_FILE` 등)과 실제 파일 객체 포인터를 함께 관리하여 FD 처리를 일원화했습니다.
    - FD 테이블의 최대 크기를 `FDTABLE_SIZE` (64)로 조정했습니다.

- **FD 관리 헬퍼 함수 추가 (`userprog/process.c`)**:
    - `process_init_fdt()`: 스레드 생성 시 FD 테이블을 초기화하고 STDIN/STDOUT을 설정합니다.
    - `process_add_file()`: 새로 열린 파일을 FD 테이블에 추가하고 fd 번호를 반환합니다.
    - `process_get_file()`: fd 번호로 FD 테이블에서 `uni_file` 객체를 조회합니다.

### 3. 시스템 콜 프레임워크 및 핸들러 구현

- **전역 파일 시스템 락 (`filesys_lock`)**:
    - `syscall.c`에 `filesys_lock`을 추가하고 `syscall_init`에서 초기화했습니다.
    - `filesys_open`, `filesys_create`, `file_read` 등 모든 파일 시스템 관련 함수 호출을 이 락으로 감싸, 파일 시스템 연산의 원자성을 보장합니다.

- **주소 유효성 검사 (`check_address`)**:
    - 시스템 콜 인자로 전달된 사용자 주소가 유효한지(NULL이 아니고, 유저 영역에 있으며, 매핑된 페이지인지) 검사하는 `check_address` 함수를 구현했습니다. 유효하지 않은 주소 접근 시 프로세스를 즉시 종료(`exit(-1)`)시킵니다.

- **시스템 콜 핸들러 구현 (`syscall.c`)**:
    - `syscall_handler`의 `switch` 문을 통해 각 시스템 콜 번호에 맞는 핸들러 함수를 호출하도록 리팩토링했습니다.
    - `halt`, `exit`, `exec`, `create`, `remove`, `open`, `filesize`, `read`, `write`, `seek`, `tell`, `close` 등 모든 필수 시스템 콜의 로직을 구현했습니다.
    - `read`/`write`는 fd 값에 따라 STDIN/STDOUT 또는 일반 파일을 구분하여 처리합니다.

### 4. 기타 변경 및 개선 사항

- **`process.c` (`load` 함수)**:
    - 실행 파일을 `load`할 때 `file_deny_write()`를 호출하여 실행 중인 파일이 수정되는 것을 방지합니다.
    - `load`가 성공하면 파일 포인터를 `thread->running_file`에 저장하고, 프로세스가 종료될 때 `process_exit`에서 닫도록 변경했습니다.

- **`exception.c` (`page_fault`)**:
    - 페이지 폴트 발생 시 `kill(f)` 대신 `exit(-1)`을 호출하여 프로세스를 표준적인 방법으로 종료하도록 수정했습니다.

- **`thread.c`**:
    - `thread_create()` 시 새로운 스레드를 부모의 `child_list`에 등록합니다.
    - `thread_yield_r()` 함수를 추가하여, 준비 큐의 맨 앞 스레드와 현재 스레드의 우선순위를 비교 후 필요할 때만 `yield` 하도록 최적화했습니다.

- **IDE 설정 (`.vscode/settings.json`)**:
    - 새로운 헤더 파일들을 C언어 파일로 인식하도록 VSCode 설정을 업데이트하여 개발 편의성을 높였습니다.

